### PR TITLE
UI: Modal component

### DIFF
--- a/components/Modal/index.jsx
+++ b/components/Modal/index.jsx
@@ -1,0 +1,131 @@
+import './style.scss';
+
+import React, { Component } from 'react';
+
+class Modal extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      visibility: props.visibility
+    };
+  }
+
+  componentWillMount() {
+    this._setConfig();
+  }
+
+  componentDidMount() {
+    if (this.props.visibility) {
+      // disables scroll window when modal is visible
+      document.querySelector('body').style.overflow = 'hidden';
+
+      this._setEventListeners();
+    }
+  }
+
+  componentDidUpdate(prevProps, nextProps) {
+    if (!nextProps.visibility) this._removeEventListeners();
+  }
+
+  _setConfig() {
+    // needs to be initialiazed and have a global scope inside the component
+    // because of adding/removing event
+    const onKeyDown= (e) => {
+      this._onKeyDown(e);
+    };
+
+    this.config = {
+      onKeyDown
+    };
+  }
+
+  _setEventListeners() {
+    document.addEventListener('keydown', this.config.onKeyDown);
+  }
+
+  _removeEventListeners() {
+    document.removeEventListener('keydown', this.config.onKeyDown);
+  }
+
+  _onKeyDown(event) {
+    // 27 => ESC key
+    if (event.keyCode !== 27) return;
+
+    this._closeModal();
+  }
+
+  _closeModal() {
+    // enables scroll window when modal is invisible
+    document.querySelector('body').style.overflow = null;
+
+    this.setState({ visibility: false });
+  }
+
+  render() {
+    return (
+      this.state.visibility &&
+        <div className={this.props.cssClasses.modal}>
+          {this.props.veil &&
+            <div
+              className={this.props.cssClasses.veil}
+              onClick={() => this._closeModal()}
+            />}
+
+          <div className={this.props.cssClasses.container}>
+            <header className={this.props.cssClasses.header}>
+              {this.props.closeable &&
+                <div
+                className={this.props.cssClasses.btnClose}
+                onClick={() => this._closeModal()}
+                />}
+            </header>
+            <section className={this.props.cssClasses.content}>
+              {this.props.children}
+            </section>
+            {this.props.hasFooter &&
+              <footer className={this.props.cssClasses.footer}>
+                <button
+                  className='btn-accept'
+                  onClick={() => this._closeModal()}
+                >
+                  Accept
+                </button>
+              </footer>}
+          </div>
+        </div>
+    );
+  }
+}
+
+Modal.propTypes = {
+  children: React.PropTypes.element.isRequired,
+  // allows set close button
+  closeable: React.PropTypes.bool,
+  // sets default CSS classes used
+  cssClasses: React.PropTypes.object,
+  // allows set a footer into the modal
+  hasFooter: React.PropTypes.bool,
+  // determinates the visibility of the modal
+  visibility: React.PropTypes.bool,
+  // allows set a veil
+  veil: React.PropTypes.bool
+};
+
+Modal.defaultProps = {
+  closeable: true,
+  cssClasses: {
+    modal: 'c-vizz-modal',
+    veil: 'veil',
+    container: 'container',
+    header: 'modal-header',
+    btnClose: 'btn-close',
+    content: 'content',
+    footer: 'modal-footer'
+  },
+  veil: true,
+  visibility: false
+};
+
+export default Modal;

--- a/components/Modal/style.scss
+++ b/components/Modal/style.scss
@@ -1,0 +1,98 @@
+
+.c-vizz-modal {
+  z-index: 100;
+
+  > .veil {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+
+    background: rgba(0, 0, 0, .8);
+  }
+
+  > .container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 80%;
+    max-width: 750px;
+    padding: 25px 32px 32px;
+    transform: translate(-50%, -50%);
+
+    background-color: #fff;
+  }
+
+  .container > .modal-header {
+    position: relative;
+    width: 100%;
+    min-height: 32px;
+  }
+
+  // sample close button
+  // credits: https://codepen.io/brissmyr/pen/egidw
+  .container > .modal-header > .btn-close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 32px;
+    height: 32px;
+
+    cursor: pointer;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      left: 15px;
+      height: 33px;
+      width: 2px;
+
+      background-color: #333;
+    }
+
+    &::before {
+      transform: rotate(45deg);
+    }
+
+    &::after {
+      transform: rotate(-45deg);
+    }
+  }
+
+  .container > .content {
+    overflow: auto;
+    max-height: 300px;
+    margin: 15px 0;
+    //avoids content overlap scroll bars
+    padding: 0 32px 0 0;
+  }
+
+  .container > .modal-footer {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    min-height: 50px;
+  }
+
+  // sample content
+  .container > .modal-footer > .btn-accept {
+    display: inline-block;
+    appearance: none;
+    padding: 10px 25px;
+    border: 0;
+    min-width: 120px;
+
+    color: #fff;
+    text-transform: uppercase;
+
+    background-color: #61b329;
+    cursor: pointer;
+
+    &:hover {
+      background-color: darken(#61b329, 5%);
+    }
+  }
+}

--- a/components/index.js
+++ b/components/index.js
@@ -1,3 +1,4 @@
 export default {};
 export { default as Globe } from './Globe';
 export { default as Spinner } from './Spinner';
+export { default as Modal} from './Modal';

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,13 +1,22 @@
 import React from 'react';
 import { storiesOf, action, linkTo } from '@kadira/storybook';
 import Globe from '../components/Globe';
+import Modal from '../components/Modal';
 import Spinner from '../components/Spinner';
 import RadioGroup from '../components/Form/RadioGroup';
 
 storiesOf('UI Components', module)
-  .add('Spinner', () => (
-    <Spinner color="black" />
-  ));
+.add('Modal', () => (
+  <Modal
+  visibility
+  hasFooter
+  >
+  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  </Modal>
+))
+.add('Spinner', () => (
+  <Spinner color="black" />
+));
 
 storiesOf('Form Components', module)
   .add('RadioGroup', () => {


### PR DESCRIPTION
Hello there!

This is the modal component. This component has the next structure:

- Modal Component
  - Veil (optional)
  - Content (modal itself, mandatory)
    - Header
    - Content
    - Footer (optional)

I have some questions about how viable is to split the `children` props (`props.children[0], props.children[1]`, ... ) to custom the content modal properly... I found really hard to fill every custom part of the modal with just one content entry point so... I would like to hear your thoughts about this, improvements on the current code and any feedback is welcome.

Thanks!
